### PR TITLE
Quick fix for unknown gamemode IDs

### DIFF
--- a/BombRushMP.Plugin/Gamemodes/GamemodeFactory.cs
+++ b/BombRushMP.Plugin/Gamemodes/GamemodeFactory.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -72,9 +72,20 @@ namespace BombRushMP.Plugin.Gamemodes
             return _defaultTeams;
         }
 
+        public static bool IsRegistered(GamemodeIDs gameModeID)
+        {
+            return Gamemodes.ContainsKey(gameModeID);
+        }
+
         public static Gamemode GetGamemode(GamemodeIDs gameModeID)
         {
-            var instance = Activator.CreateInstance(Gamemodes[gameModeID]) as Gamemode;
+            if (!Gamemodes.TryGetValue(gameModeID, out var gamemodeType))
+            {
+                Debug.LogWarning($"Unknown gamemode '{gameModeID}', falling back to Score Battle.");
+                gamemodeType = Gamemodes[GamemodeIDs.ScoreBattle];
+            }
+
+            var instance = Activator.CreateInstance(gamemodeType) as Gamemode;
             return instance;
         }
 
@@ -103,7 +114,10 @@ namespace BombRushMP.Plugin.Gamemodes
 
         public static string GetGamemodeName(GamemodeIDs gameModeID)
         {
-            return GamemodeNames[gameModeID];
+            if (!GamemodeNames.TryGetValue(gameModeID, out var gamemodeName))
+                return "Unknown";
+
+            return gamemodeName;
         }
     }
 }


### PR DESCRIPTION
The game crashes if the player flips all the way through the end of the Gamemode dictionary (in Lobby settings). This prevents the crash when the lobby gamemode is missing, like for Custom.

BepInExLog:
```[Error  : Unity Log] KeyNotFoundException: The given key 'Custom' was not present in the dictionary.
Stack trace:
System.Collections.Generic.Dictionary`2[TKey,TValue].get_Item (TKey key) (at <88e4733ac7bc4ae1b496735e6b83bbd3>:0)
BombRushMP.Plugin.Gamemodes.GamemodeFactory.GetGamemode (BombRushMP.Common.GamemodeIDs gameModeID) (at C:/Users/Nahue/BombRushMP/BombRushMP.Plugin/Gamemodes/GamemodeFactory.cs:77)
BombRushMP.Plugin.Gamemodes.GamemodeFactory.GetGamemodeSettings (BombRushMP.Common.GamemodeIDs gameModeID) (at C:/Users/Nahue/BombRushMP/BombRushMP.Plugin/Gamemodes/GamemodeFactory.cs:83)
BombRushMP.Plugin.Phone.AppMultiplayerCurrentLobby+<>c__DisplayClass9_0.<RefreshApp>b__2 () (at C:/Users/Nahue/BombRushMP/BombRushMP.Plugin/Phone/AppMultiplayerCurrentLobby.cs:108)
CommonAPI.Phone.PhoneButton.Confirm () (at <285f5708d26c44c49e2189c4f620e399>:0)
CommonAPI.Phone.PhoneScrollView.OnReleaseRight () (at <285f5708d26c44c49e2189c4f620e399>:0)
CommonAPI.Phone.CustomApp.OnReleaseRight () (at <285f5708d26c44c49e2189c4f620e399>:0)
(wrapper dynamic-method) Reptile.Phone.Phone.DMD<Reptile.Phone.Phone::GetInput>(Reptile.Phone.Phone,Reptile.Phone.App)
Reptile.Phone.Phone.OSUpdate () (at <e7d5b3bb037947ef98da01aaf09c9871>:0)
Reptile.Phone.Phone.PhoneUpdate () (at <e7d5b3bb037947ef98da01aaf09c9871>:0)
(wrapper dynamic-method) Reptile.Player.DMD<Reptile.Player::UpdatePlayer>(Reptile.Player)
Reptile.WorldHandler.UpdateWorldHandler () (at <e7d5b3bb037947ef98da01aaf09c9871>:0)
Reptile.Core.SendUpdateEvent () (at <e7d5b3bb037947ef98da01aaf09c9871>:0)
Reptile.Core.UpdateWithExceptionHandling () (at <e7d5b3bb037947ef98da01aaf09c9871>:0)
UnityEngine.Debug:LogException(Exception)
ErrorHandler.Plugin.Patches.CorePatch:HandleExceptionInGame_Prefix(Core, Exception)
Reptile.Core:DMD<Reptile.Core::HandleExceptionInGame>(Core, Exception)
Reptile.Core:UpdateWithExceptionHandling()
Reptile.Core:Update()